### PR TITLE
Add FastAPI core auth module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///./test.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml poetry.lock* /app/
+RUN pip install poetry && poetry install --no-interaction --no-root
+COPY backend /app/backend
+CMD ["poetry", "run", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # AI-Orchestrator
-Минимальный Telegram-бот-оркестратор.
+
+Пример базового модуля Core Platform на FastAPI. Запуск локально:
+
+```bash
+docker-compose up --build
+```
+
+После запуска приложение будет доступно на `http://localhost:8000` и содержит
+простые эндпоинты аутентификации `/auth/register` и `/auth/login`.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from . import auth
+
+api_router = APIRouter()
+api_router.include_router(auth.router, prefix="/auth", tags=["auth"])

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from ..schemas import UserCreate, Token
+from ..config.database import SessionLocal
+from ..services.auth import AuthService
+
+router = APIRouter()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post("/register", response_model=Token)
+def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    service = AuthService(db)
+    user = service.register(user_in)
+    access_token = service.create_access_token_for_user(user)
+    return Token(access_token=access_token)
+
+@router.post("/login", response_model=Token)
+def login(user_in: UserCreate, db: Session = Depends(get_db)):
+    service = AuthService(db)
+    user = service.authenticate(user_in.email, user_in.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    access_token = service.create_access_token_for_user(user)
+    return Token(access_token=access_token)

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -1,0 +1,4 @@
+from .settings import get_settings
+from .database import SessionLocal, Base, engine
+
+__all__ = ["get_settings", "SessionLocal", "Base", "engine"]

--- a/backend/app/config/database.py
+++ b/backend/app/config/database.py
@@ -1,0 +1,8 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from .settings import get_settings
+
+settings = get_settings()
+engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "AI Agents Ecosystem"
+    secret_key: str = "secret"
+    algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
+    database_url: str = "sqlite:///./test.db"
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,3 @@
+from .security import create_access_token, verify_password, get_password_hash
+
+__all__ = ["create_access_token", "verify_password", "get_password_hash"]

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+from jose import jwt
+from passlib.context import CryptContext
+from ..config.settings import get_settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+settings = get_settings()
+
+
+def create_access_token(subject: str, expires_delta: timedelta | None = None) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
+    expire = datetime.utcnow() + expires_delta
+    to_encode = {"exp": expire, "sub": str(subject)}
+    encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+    return encoded_jwt
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from .api import auth
+from .config.database import Base, engine
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="AI Agents Ecosystem")
+app.include_router(auth.router, prefix="/auth", tags=["auth"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .base import Base
+from .user import User
+
+__all__ = ["Base", "User"]

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,3 @@
+from ..config.database import Base
+
+__all__ = ["Base"]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, String, Boolean, DateTime
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from .base import Base
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(String, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    full_name = Column(String, nullable=True)
+    is_active = Column(Boolean, default=True)
+    is_superuser = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .user import UserCreate, UserRead
+from .auth import Token, TokenPayload
+
+__all__ = ["UserCreate", "UserRead", "Token", "TokenPayload"]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class TokenPayload(BaseModel):
+    sub: str | None = None
+    exp: int | None = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, EmailStr
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+    full_name: str | None = None
+
+class UserRead(BaseModel):
+    id: str
+    email: EmailStr
+    full_name: str | None = None
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,4 @@
+from .user import UserService
+from .auth import AuthService
+
+__all__ = ["UserService", "AuthService"]

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+from sqlalchemy.orm import Session
+from ..models import User
+from ..schemas import UserCreate
+from ..core.security import verify_password, create_access_token
+from .user import UserService
+from ..config.settings import get_settings
+
+settings = get_settings()
+
+class AuthService:
+    def __init__(self, db: Session):
+        self.db = db
+        self.user_service = UserService(db)
+
+    def authenticate(self, email: str, password: str) -> User | None:
+        user = self.user_service.get_by_email(email)
+        if not user:
+            return None
+        if not verify_password(password, user.hashed_password):
+            return None
+        return user
+
+    def create_access_token_for_user(self, user: User) -> str:
+        return create_access_token(subject=user.id, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))
+
+    def register(self, user_in: UserCreate) -> User:
+        return self.user_service.create_user(user_in)

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+from uuid import uuid4
+from ..models import User
+from ..schemas import UserCreate
+from ..core.security import get_password_hash
+
+class UserService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_user(self, user_in: UserCreate) -> User:
+        user = User(
+            id=str(uuid4()),
+            email=user_in.email,
+            hashed_password=get_password_hash(user_in.password),
+            full_name=user_in.full_name,
+        )
+        self.db.add(user)
+        self.db.commit()
+        self.db.refresh(user)
+        return user
+
+    def get_by_email(self, email: str) -> User | None:
+        return self.db.query(User).filter(User.email == email).first()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,38 @@
+import pytest
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from backend.app.config.database import Base
+from backend.app.main import app
+from backend.app.config.database import get_settings
+
+settings = get_settings()
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    yield
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+@pytest.mark.asyncio
+async def test_register_and_login():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/auth/register", json={"email": "a@a.com", "password": "pass"})
+        assert resp.status_code == 200
+        token = resp.json()["access_token"]
+        assert token
+
+        resp = await ac.post("/auth/login", json={"email": "a@a.com", "password": "pass"})
+        assert resp.status_code == 200
+        assert resp.json()["access_token"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app/backend
+    environment:
+      - PYTHONUNBUFFERED=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,26 @@
 [tool.poetry]
 name = "ai-orchestrator"
 version = "0.1.0"
-description = "Telegram-based AI Orchestrator"
+description = "AI Agents Ecosystem Core Platform"
 authors = ["Mikhail Singatullin <you@example.com>"]
 readme = "README.md"
-packages = [{ include = "ai_orchestrator" }]
+packages = [{ include = "backend" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-python-telegram-bot = "^21.11.1"
-python-dotenv = "^1.1"
+fastapi = "^0.111"
+uvicorn = "^0.29"
+sqlalchemy = "^2.0"
+alembic = "^1.13"
+psycopg2-binary = "^2.9"
+passlib = {extras = ["bcrypt"], version = "^1.7"}
+python-jose = {extras = ["cryptography"], version = "^3.3"}
+pydantic = "^2.7"
+pydantic-settings = "^2.2"
+python-dotenv = "^1.0"
+pytest = "^8.2"
+pytest-asyncio = "^0.23"
+httpx = "^0.27"
 
 [build-system]
 requires = ["poetry-core>=1.7.0"]


### PR DESCRIPTION
## Summary
- initialize FastAPI backend skeleton
- implement simple auth service and routes
- provide sqlite-backed SQLAlchemy models
- add docker setup and example env
- include a basic async test for registration and login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688624a9fb00832ca3094dcd81ea72c4