### PR TITLE
Add data collection skeleton with privacy services

### DIFF
--- a/backend/app/data_collection/models/__init__.py
+++ b/backend/app/data_collection/models/__init__.py
@@ -1,0 +1,11 @@
+from .raw_data import RawMessage
+from .processed_data import ProcessedMessage
+from .conversation import ConversationContext
+from .user_style import UserCommunicationStyle
+
+__all__ = [
+    "RawMessage",
+    "ProcessedMessage",
+    "ConversationContext",
+    "UserCommunicationStyle",
+]

--- a/backend/app/data_collection/models/conversation.py
+++ b/backend/app/data_collection/models/conversation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class ConversationContext(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    user_id: UUID
+    conversation_id: str
+    source: str
+    participant_count: int
+    start_time: datetime
+    end_time: datetime
+    message_count: int
+    topic_keywords: List[str] = Field(default_factory=list)
+    conversation_type: str
+    average_response_time: float | None = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/data_collection/models/processed_data.py
+++ b/backend/app/data_collection/models/processed_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class ProcessedMessage(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    raw_message_id: UUID
+    cleaned_text: str
+    language: str
+    sentiment_score: float
+    emotion_tags: List[str] = Field(default_factory=list)
+    message_type: str
+    formality_level: float
+    response_time_minutes: int | None = None
+    contains_emoji: bool = False
+    word_count: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/data_collection/models/raw_data.py
+++ b/backend/app/data_collection/models/raw_data.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class RawMessage(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    user_id: UUID
+    source: str
+    source_id: str
+    raw_content: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime
+    is_outgoing: bool
+    conversation_id: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/data_collection/models/user_style.py
+++ b/backend/app/data_collection/models/user_style.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class UserCommunicationStyle(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    user_id: UUID
+    source: str
+    avg_message_length: float
+    formality_score: float
+    emoji_usage_rate: float
+    response_time_pattern: Dict[str, float] = Field(default_factory=dict)
+    vocabulary_complexity: float | None = None
+    sentence_structure: Dict[str, float] = Field(default_factory=dict)
+    common_phrases: List[str] = Field(default_factory=list)
+    sentiment_distribution: Dict[str, float] = Field(default_factory=dict)
+    emotion_patterns: Dict[str, float] = Field(default_factory=dict)
+    active_hours: List[int] = Field(default_factory=list)
+    conversation_starters: List[str] = Field(default_factory=list)
+    typical_responses: Dict[str, str] = Field(default_factory=dict)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/data_collection/services/__init__.py
+++ b/backend/app/data_collection/services/__init__.py
@@ -1,0 +1,4 @@
+from .privacy_service import PrivacyService
+from .data_retention import DataRetentionService
+
+__all__ = ["PrivacyService", "DataRetentionService"]

--- a/backend/app/data_collection/services/data_retention.py
+++ b/backend/app/data_collection/services/data_retention.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID
+
+
+class DataRetentionService:
+    """Manage lifecycle of user data."""
+
+    async def schedule_data_deletion(self, user_id: UUID, days: int) -> datetime:
+        return datetime.utcnow() + timedelta(days=days)
+
+    async def anonymize_old_data(self, cutoff_date: datetime) -> bool:
+        # Placeholder for anonymization logic
+        return True
+
+    async def export_user_data(self, user_id: UUID) -> dict:
+        # Placeholder for exporting logic
+        return {"user_id": str(user_id)}
+
+    async def delete_user_data(self, user_id: UUID) -> bool:
+        # Placeholder for deletion logic
+        return True

--- a/backend/app/data_collection/services/privacy_service.py
+++ b/backend/app/data_collection/services/privacy_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+import secrets
+from hashlib import sha256
+from typing import Any
+
+from cryptography.fernet import Fernet
+
+
+class PrivacyService:
+    """Simple privacy helper with symmetric encryption."""
+
+    def __init__(self, key: bytes | None = None) -> None:
+        self._key = key or Fernet.generate_key()
+        self._fernet = Fernet(self._key)
+
+    @property
+    def key(self) -> bytes:
+        return self._key
+
+    def encrypt_message_content(self, content: str) -> str:
+        return self._fernet.encrypt(content.encode()).decode()
+
+    def decrypt_message_content(self, encrypted_content: str) -> str:
+        return self._fernet.decrypt(encrypted_content.encode()).decode()
+
+    def hash_conversation_id(self, original_id: str) -> str:
+        return sha256(original_id.encode()).hexdigest()
+
+    def remove_pii(self, text: str) -> str:
+        email_re = r"[\w\.-]+@[\w\.-]+"
+        phone_re = r"\+?\d[\d -]{7,}\d"
+        text = re.sub(email_re, "[email]", text)
+        text = re.sub(phone_re, "[phone]", text)
+        return text

--- a/backend/tests/test_privacy.py
+++ b/backend/tests/test_privacy.py
@@ -1,0 +1,22 @@
+from uuid import uuid4
+
+import pytest
+
+from backend.app.data_collection.services import PrivacyService, DataRetentionService
+
+
+@pytest.mark.asyncio
+async def test_privacy_encryption_roundtrip():
+    service = PrivacyService()
+    text = "secret message"
+    encrypted = service.encrypt_message_content(text)
+    assert encrypted != text
+    decrypted = service.decrypt_message_content(encrypted)
+    assert decrypted == text
+
+
+@pytest.mark.asyncio
+async def test_data_retention_schedule():
+    retention = DataRetentionService()
+    future = await retention.schedule_data_deletion(uuid4(), 7)
+    assert future


### PR DESCRIPTION
## Summary
- scaffold `data_collection` module
- define data models for raw and processed messages
- add privacy and data retention services
- include basic async tests for encryption and data retention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886763610f4832cb14531b0e7f3af5b