### PR TITLE
Implement NLP pipeline and new parsers

### DIFF
--- a/backend/app/api/data_collection.py
+++ b/backend/app/api/data_collection.py
@@ -4,9 +4,15 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from ..config.database import SessionLocal
-from ..data_collection.parsers.telegram import TelegramParser
+from ..data_collection.parsers import (
+    TelegramParser,
+    EmailParser,
+    WhatsAppParser,
+)
 from ..data_collection.services.collection_service import CollectionService
 from ..data_collection.schemas.collection import RawMessageRead
+from ..data_collection.nlp import NLPPipeline
+from ..data_collection.models.processed_data import ProcessedMessage
 
 router = APIRouter()
 
@@ -28,8 +34,34 @@ def ingest_telegram_message(payload: dict, user_id: str, db: Session = Depends(g
     return msg
 
 
+@router.post("/email", response_model=RawMessageRead)
+def ingest_email_message(payload: dict, user_id: str, db: Session = Depends(get_db)):
+    parser = EmailParser()
+    data = parser.parse(payload, user_id)
+    service = CollectionService(db)
+    msg = service.create_raw_message(data)
+    return msg
+
+
+@router.post("/whatsapp", response_model=RawMessageRead)
+def ingest_whatsapp_message(payload: dict, user_id: str, db: Session = Depends(get_db)):
+    parser = WhatsAppParser()
+    data = parser.parse(payload, user_id)
+    service = CollectionService(db)
+    msg = service.create_raw_message(data)
+    return msg
+
+
 @router.get("/raw/{message_id}", response_model=RawMessageRead)
 def get_raw_message(message_id: str, db: Session = Depends(get_db)):
     service = CollectionService(db)
     msg = service.get_raw_message(message_id)
     return msg
+
+
+@router.post("/process/{message_id}", response_model=ProcessedMessage)
+def process_message(message_id: str, db: Session = Depends(get_db)):
+    service = CollectionService(db)
+    msg = service.get_raw_message(message_id)
+    pipeline = NLPPipeline()
+    return pipeline.process(msg)

--- a/backend/app/data_collection/nlp/__init__.py
+++ b/backend/app/data_collection/nlp/__init__.py
@@ -1,0 +1,5 @@
+from .nlp_pipeline import NLPPipeline
+from .sentiment_analyzer import SentimentAnalyzer
+from .style_analyzer import StyleAnalyzer
+
+__all__ = ["NLPPipeline", "SentimentAnalyzer", "StyleAnalyzer"]

--- a/backend/app/data_collection/nlp/nlp_pipeline.py
+++ b/backend/app/data_collection/nlp/nlp_pipeline.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+import string
+from .sentiment_analyzer import SentimentAnalyzer
+from ..models import ProcessedMessage, RawMessage
+
+
+class NLPPipeline:
+    """Simple NLP processing pipeline for raw messages."""
+
+    emoji_re = re.compile(r"[\U0001F600-\U0001F64F]")
+
+    def __init__(self) -> None:
+        self.sentiment = SentimentAnalyzer()
+
+    def clean_text(self, text: str) -> str:
+        text = text.strip()
+        return text.translate(str.maketrans("", "", string.punctuation))
+
+    def detect_language(self, text: str) -> str:
+        if re.search(r"[а-яА-Я]", text):
+            return "ru"
+        return "en"
+
+    def formality_level(self, text: str) -> float:
+        tokens = text.lower().split()
+        polite = {"please", "thank", "thanks"}
+        if not tokens:
+            return 0.0
+        count = sum(1 for t in tokens if t in polite)
+        return count / len(tokens)
+
+    def process(self, message: RawMessage) -> ProcessedMessage:
+        cleaned = self.clean_text(message.raw_content)
+        language = self.detect_language(cleaned)
+        sentiment = self.sentiment.analyze(cleaned)
+        contains_emoji = bool(self.emoji_re.search(message.raw_content))
+        word_count = len(cleaned.split())
+        formality = self.formality_level(cleaned)
+        return ProcessedMessage(
+            raw_message_id=message.id,
+            cleaned_text=cleaned,
+            language=language,
+            sentiment_score=sentiment,
+            emotion_tags=[],
+            message_type="text",
+            formality_level=formality,
+            response_time_minutes=None,
+            contains_emoji=contains_emoji,
+            word_count=word_count,
+        )

--- a/backend/app/data_collection/nlp/sentiment_analyzer.py
+++ b/backend/app/data_collection/nlp/sentiment_analyzer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import string
+
+POSITIVE_WORDS = {
+    "good",
+    "great",
+    "excellent",
+    "happy",
+    "love",
+    "awesome",
+    "nice",
+}
+
+NEGATIVE_WORDS = {
+    "bad",
+    "terrible",
+    "sad",
+    "hate",
+    "awful",
+    "horrible",
+}
+
+class SentimentAnalyzer:
+    """Naive rule based sentiment analyzer."""
+
+    def analyze(self, text: str) -> float:
+        words = [w.strip(string.punctuation).lower() for w in text.split()]
+        pos = sum(1 for w in words if w in POSITIVE_WORDS)
+        neg = sum(1 for w in words if w in NEGATIVE_WORDS)
+        total = pos + neg
+        if total == 0:
+            return 0.0
+        return (pos - neg) / total

--- a/backend/app/data_collection/nlp/style_analyzer.py
+++ b/backend/app/data_collection/nlp/style_analyzer.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from statistics import mean
+from typing import Iterable
+
+from ..models import ProcessedMessage, UserCommunicationStyle
+
+
+class StyleAnalyzer:
+    """Analyze a user's communication style from processed messages."""
+
+    def analyze(
+        self, messages: Iterable[ProcessedMessage], user_id: str, source: str
+    ) -> UserCommunicationStyle:
+        msgs = list(messages)
+        if not msgs:
+            return UserCommunicationStyle(
+                user_id=user_id,
+                source=source,
+                avg_message_length=0,
+                formality_score=0,
+                emoji_usage_rate=0,
+            )
+
+        avg_len = mean(m.word_count for m in msgs)
+        formality = mean(m.formality_level for m in msgs)
+        emoji_rate = sum(1 for m in msgs if m.contains_emoji) / len(msgs)
+
+        return UserCommunicationStyle(
+            user_id=user_id,
+            source=source,
+            avg_message_length=avg_len,
+            formality_score=formality,
+            emoji_usage_rate=emoji_rate,
+        )

--- a/backend/app/data_collection/parsers/__init__.py
+++ b/backend/app/data_collection/parsers/__init__.py
@@ -1,0 +1,5 @@
+from .telegram import TelegramParser
+from .email import EmailParser
+from .whatsapp import WhatsAppParser
+
+__all__ = ["TelegramParser", "EmailParser", "WhatsAppParser"]

--- a/backend/app/data_collection/parsers/email.py
+++ b/backend/app/data_collection/parsers/email.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from ..schemas.collection import RawMessageCreate
+
+
+class EmailParser:
+    """Parser for email message payloads."""
+
+    @staticmethod
+    def parse(payload: Dict[str, Any], user_id: str) -> RawMessageCreate:
+        date = payload.get("date")
+        if isinstance(date, str):
+            try:
+                ts = datetime.fromisoformat(date)
+            except ValueError:
+                ts = datetime.utcnow()
+        else:
+            ts = datetime.utcnow()
+        return RawMessageCreate(
+            user_id=user_id,
+            source="email",
+            source_id=str(payload.get("id")),
+            raw_content=str(payload.get("body", "")),
+            timestamp=ts,
+            is_outgoing=bool(payload.get("outgoing", False)),
+            conversation_id=str(payload.get("thread_id", "")),
+            metadata={k: v for k, v in payload.items() if k not in {"id", "body", "date", "outgoing", "thread_id"}},
+        )

--- a/backend/app/data_collection/parsers/whatsapp.py
+++ b/backend/app/data_collection/parsers/whatsapp.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from ..schemas.collection import RawMessageCreate
+
+
+class WhatsAppParser:
+    """Parser for WhatsApp message payloads."""
+
+    @staticmethod
+    def parse(payload: Dict[str, Any], user_id: str) -> RawMessageCreate:
+        ts_val = payload.get("timestamp")
+        if isinstance(ts_val, (int, float)):
+            ts = datetime.fromtimestamp(ts_val)
+        else:
+            ts = datetime.utcnow()
+        return RawMessageCreate(
+            user_id=user_id,
+            source="whatsapp",
+            source_id=str(payload.get("id")),
+            raw_content=str(payload.get("text", "")),
+            timestamp=ts,
+            is_outgoing=bool(payload.get("from_me", False)),
+            conversation_id=str(payload.get("chat_id", "")),
+            metadata={k: v for k, v in payload.items() if k not in {"id", "text", "timestamp", "from_me", "chat_id"}},
+        )

--- a/backend/app/data_collection/schemas/collection.py
+++ b/backend/app/data_collection/schemas/collection.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Dict, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
 
 
 class RawMessageBase(BaseModel):
@@ -11,7 +12,7 @@ class RawMessageBase(BaseModel):
     source: str
     source_id: str
     raw_content: str
-    metadata: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = Field(default_factory=dict, alias="message_metadata")
     timestamp: datetime
     is_outgoing: bool = False
     conversation_id: Optional[str] = None
@@ -25,6 +26,4 @@ class RawMessageRead(RawMessageBase):
     id: str
     created_at: datetime
 
-    class Config:
-        orm_mode = True
-        fields = {"metadata": "message_metadata"}
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/backend/tests/test_parsers_and_nlp.py
+++ b/backend/tests/test_parsers_and_nlp.py
@@ -1,0 +1,93 @@
+import pytest
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from httpx import AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from backend.app.config.database import Base
+from backend.app.main import app, startup_event
+from fastapi_limiter import FastAPILimiter
+from backend.app.config.database import get_settings
+from backend.app.data_collection.nlp import NLPPipeline, StyleAnalyzer
+from backend.app.data_collection.models.raw_data import RawMessage
+from datetime import datetime
+
+settings = get_settings()
+settings.redis_url = ""
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    yield
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+@pytest.mark.asyncio
+async def test_email_ingest_and_pipeline():
+    class DummyRedis:
+        async def evalsha(self, *args, **kwargs):
+            return None
+
+    FastAPILimiter.redis = DummyRedis()
+    async def ident(request):
+        return "test"
+    FastAPILimiter.identifier = ident
+    async def cb(request, response, pexpire):
+        return None
+    FastAPILimiter.http_callback = cb
+    await startup_event()
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        payload = {
+            "id": "1",
+            "body": "I love this product!",
+            "date": datetime.utcnow().isoformat(),
+        }
+        resp = await ac.post("/data-collection/email", json=payload, params={"user_id": "u1"})
+        assert resp.status_code == 200
+        message_id = resp.json()["id"]
+
+        resp = await ac.post(f"/data-collection/process/{message_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sentiment_score"] > 0
+
+def test_style_analyzer():
+    msgs = [
+        RawMessage(
+            id="11111111-1111-1111-1111-111111111111",
+            user_id="11111111-1111-1111-1111-111111111111",
+            organization_id=None,
+            source="telegram",
+            source_id="1",
+            raw_content="Thanks!",
+            message_metadata={},
+            timestamp=datetime.utcnow(),
+            is_outgoing=False,
+            conversation_id="c1",
+        ),
+        RawMessage(
+            id="22222222-2222-2222-2222-222222222222",
+            user_id="11111111-1111-1111-1111-111111111111",
+            organization_id=None,
+            source="telegram",
+            source_id="2",
+            raw_content="Hello :)",
+            message_metadata={},
+            timestamp=datetime.utcnow(),
+            is_outgoing=False,
+            conversation_id="c1",
+        ),
+    ]
+    pipeline = NLPPipeline()
+    processed = [pipeline.process(m) for m in msgs]
+    analyzer = StyleAnalyzer()
+    style = analyzer.analyze(processed, user_id="11111111-1111-1111-1111-111111111111", source="telegram")
+    assert style.avg_message_length > 0
+


### PR DESCRIPTION
## Summary
- implement simple NLP pipeline with sentiment and style analyzers
- add email and WhatsApp parsers
- expose new ingestion and NLP endpoints
- provide tests for parsers and NLP pipeline

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868451a2bc832c88560883ae961750