### PR TITLE
Implement async LLM backend

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 30
     database_url: str = "sqlite:///./test.db"
     redis_url: str = "redis://localhost:6379/0"
+    llm_provider: str = "simple"
+    openai_api_key: str | None = None
 
     class Config:
         env_file = ".env"

--- a/backend/app/digital_twin/services/__init__.py
+++ b/backend/app/digital_twin/services/__init__.py
@@ -1,5 +1,12 @@
 from .digital_twin_service import DigitalTwinService
 from .agent_runner import AgentRunner
 from .feedback_handler import FeedbackHandler
+from .llm_backends import LLMBackend, get_backend
 
-__all__ = ["DigitalTwinService", "AgentRunner", "FeedbackHandler"]
+__all__ = [
+    "DigitalTwinService",
+    "AgentRunner",
+    "FeedbackHandler",
+    "LLMBackend",
+    "get_backend",
+]

--- a/backend/app/digital_twin/services/digital_twin_service.py
+++ b/backend/app/digital_twin/services/digital_twin_service.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 from typing import Dict
 from uuid import UUID
 
+from ...config.settings import get_settings
 from ..models.digital_twin import DigitalTwin, PersonalityProfile
+from .llm_backends import get_backend
 
 
 class DigitalTwinService:
     """Manage Digital Twins in-memory."""
 
-    def __init__(self):
+    def __init__(self, llm_provider: str | None = None):
+        settings = get_settings()
+        self.default_provider = llm_provider or settings.llm_provider
         self.twins: Dict[UUID, DigitalTwin] = {}
         self.profiles: Dict[UUID, PersonalityProfile] = {}
         self.memory: Dict[UUID, list[str]] = {}
@@ -31,5 +35,28 @@ class DigitalTwinService:
         twin = await self.get_twin(twin_id)
         self.memory.setdefault(twin_id, []).append(query)
         recent = self.memory[twin_id][-twin.context_window :]
+        profile = self.profiles.get(twin_id)
         tone = twin.style_profile.get("tone") if twin.style_profile else "neutral"
-        return f"{twin.name} [{tone}] says: {query} | ctx:{len(recent)}"
+
+        prompt = "\n".join(
+            [
+                f"Personality: {profile.description if profile else ''}",
+                f"Tone: {tone}",
+                "Recent conversation:",
+                *recent,
+                f"User: {query}",
+                f"{twin.name}:",
+            ]
+        )
+
+        backend = get_backend(twin.llm_backend or self.default_provider)
+        response = await backend.generate(
+            prompt,
+            twin=twin,
+            query=query,
+            recent=recent,
+            tone=tone,
+            profile=profile,
+        )
+        self.memory[twin_id].append(response)
+        return response

--- a/backend/app/digital_twin/services/llm_backends.py
+++ b/backend/app/digital_twin/services/llm_backends.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import openai
+except Exception:  # pragma: no cover - if import fails fall back to simple backend
+    openai = None
+
+
+class LLMBackend:
+    """Base interface for text generation backends."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class SimpleBackend(LLMBackend):
+    """Trivial backend that echoes the last user message."""
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        twin = kwargs.get("twin")
+        query = kwargs.get("query", "")
+        tone = kwargs.get("tone", "neutral")
+        recent = kwargs.get("recent", [])
+        await asyncio.sleep(0)
+        name = twin.name if twin else "Twin"
+        return f"{name} [{tone}] says: {query} | ctx:{len(recent)}"
+
+
+class OpenAIBackend(LLMBackend):
+    """Backend using OpenAI's chat completion API."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None) -> None:
+        if openai is None:
+            raise RuntimeError("openai package not installed")
+        self.model = model
+        openai.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
+    async def generate(self, prompt: str, **kwargs: Any) -> str:
+        resp = await openai.ChatCompletion.acreate(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+
+
+def get_backend(name: str) -> LLMBackend:
+    name = (name or "simple").lower()
+    if name == "openai" and openai is not None:
+        try:
+            return OpenAIBackend()
+        except Exception:
+            pass
+    return SimpleBackend()

--- a/backend/app/vector_db/__init__.py
+++ b/backend/app/vector_db/__init__.py
@@ -1,8 +1,12 @@
 from .services.embedding_service import EmbeddingService
-from .services.transformers_embedding import TransformersEmbeddingService
 from .services.search_service import SearchService
 from .services.vector_store import VectorStoreService
 from .models.embeddings import MessageEmbedding
+
+try:  # pragma: no cover - optional heavy dependency
+    from .services.transformers_embedding import TransformersEmbeddingService
+except Exception:  # pragma: no cover - fallback when dependency missing
+    TransformersEmbeddingService = None
 
 __all__ = [
     "EmbeddingService",


### PR DESCRIPTION
## Summary
- add `llm_provider` and optional OpenAI key to app settings
- implement pluggable LLM backends with a simple and OpenAI implementation
- use profile and context when generating a twin's response
- export LLM backend helpers
- gracefully handle missing sentence-transformers dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a177070832c8620832b345b3d4c