### PR TITLE
Add tests for style and digital twin logic

### DIFF
--- a/backend/tests/test_digital_twin_style.py
+++ b/backend/tests/test_digital_twin_style.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.digital_twin.services.digital_twin_service import DigitalTwinService
+from backend.app.digital_twin.api import digital_twin as api_module
+from backend.app.main import app, startup_event
+from httpx import AsyncClient, ASGITransport
+from fastapi_limiter import FastAPILimiter
+
+
+@pytest.mark.asyncio
+async def test_service_style_and_context():
+    service = DigitalTwinService()
+    twin = await service.create_digital_twin(uuid4(), "Tester")
+    service.twins[twin.id].style_profile = {"tone": "friendly"}
+    service.twins[twin.id].context_window = 2
+
+    resp1 = await service.generate_response(twin.id, "Hi")
+    assert resp1.endswith("ctx:1")
+    assert "friendly" in resp1
+
+    await service.generate_response(twin.id, "How are you?")
+    resp3 = await service.generate_response(twin.id, "Tell me more")
+    assert resp3.endswith("ctx:2")
+    assert "friendly" in resp3
+
+
+@pytest.mark.asyncio
+async def test_api_style_and_context(monkeypatch):
+    class DummyRedis:
+        async def evalsha(self, *args, **kwargs):
+            return None
+
+    FastAPILimiter.redis = DummyRedis()
+
+    async def ident(request):
+        return "test"
+
+    FastAPILimiter.identifier = ident
+
+    async def cb(request, response, pexpire):
+        return None
+
+    FastAPILimiter.http_callback = cb
+    await startup_event()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        user_id = uuid4()
+        resp = await ac.post("/digital-twin/create", params={"user_id": user_id, "name": "Tester"})
+        assert resp.status_code == 200
+        twin_id = resp.json()["id"]
+
+        twin_uuid = UUID(twin_id)
+        api_module.service.twins[twin_uuid].style_profile = {"tone": "friendly"}
+        api_module.service.twins[twin_uuid].context_window = 2
+
+        await ac.post(f"/digital-twin/{twin_id}/generate", params={"query": "Hi"})
+        resp = await ac.post(f"/digital-twin/{twin_id}/generate", params={"query": "More"})
+        assert resp.status_code == 200
+        assert resp.json()["response"].endswith("ctx:2")
+        assert "friendly" in resp.json()["response"]

--- a/backend/tests/test_vector_api_mock.py
+++ b/backend/tests/test_vector_api_mock.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.main import app, startup_event
+from fastapi_limiter import FastAPILimiter
+from httpx import AsyncClient, ASGITransport
+from backend.app.api import vector_db
+from backend.app.data_collection.models.processed_data import ProcessedMessage
+
+
+class DummyEmbedder:
+    dimension = 10
+
+    def encode_text(self, text: str):
+        return [0.1] * self.dimension
+
+
+@pytest.mark.asyncio
+async def test_vector_api_with_mock(monkeypatch):
+    class DummyRedis:
+        async def evalsha(self, *args, **kwargs):
+            return None
+
+    FastAPILimiter.redis = DummyRedis()
+    async def ident(request):
+        return "test"
+    FastAPILimiter.identifier = ident
+    async def cb(request, response, pexpire):
+        return None
+    FastAPILimiter.http_callback = cb
+    await startup_event()
+
+    monkeypatch.setattr(vector_db, "search", vector_db.SearchService(embedder=DummyEmbedder()))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        user_id = uuid4()
+        data = ProcessedMessage(
+            raw_message_id=uuid4(),
+            cleaned_text="hello world",
+            language="en",
+            sentiment_score=0.1,
+            message_type="text",
+            formality_level=0.1,
+        )
+        payload = {k: (str(v) if hasattr(v, "hex") else v) for k, v in data.model_dump().items()}
+        resp = await ac.post("/vectors/index", json=payload, params={"user_id": str(user_id)})
+        assert resp.status_code == 200
+        emb_id = resp.json()["embedding_id"]
+
+        resp = await ac.get("/vectors/search", params={"user_id": str(user_id), "query": "hello"})
+        assert resp.status_code == 200
+        assert emb_id in resp.json()["results"]


### PR DESCRIPTION
## Summary
- add a test covering digital twin style tone and context window logic
- add a vector API test mocking the embedding service

## Testing
- `pytest -q` *(fails: pydantic-core build error)*

------
https://chatgpt.com/codex/tasks/task_e_68869a1860dc832c94bc45fbe023a958