### PR TITLE
Enhance style analyzer and embedder fallback

### DIFF
--- a/backend/tests/test_parsers_and_nlp.py
+++ b/backend/tests/test_parsers_and_nlp.py
@@ -89,6 +89,13 @@ def test_style_analyzer():
     pipeline = NLPPipeline()
     processed = [pipeline.process(m) for m in msgs]
     analyzer = StyleAnalyzer()
-    style = analyzer.analyze(processed, user_id="11111111-1111-1111-1111-111111111111", source="telegram")
+    style = analyzer.analyze(
+        processed,
+        user_id="11111111-1111-1111-1111-111111111111",
+        source="telegram",
+    )
     assert style.avg_message_length > 0
+    assert style.dominant_sentiment in {"positive", "neutral", "negative"}
+    assert style.sentiment_distribution
+    assert style.emotion_patterns == {}
 

--- a/backend/tests/test_vector_api_mock.py
+++ b/backend/tests/test_vector_api_mock.py
@@ -48,7 +48,14 @@ async def test_vector_api_with_mock(monkeypatch):
             message_type="text",
             formality_level=0.1,
         )
-        payload = {k: (str(v) if hasattr(v, "hex") else v) for k, v in data.model_dump().items()}
+        def conv(v):
+            if hasattr(v, "hex"):
+                return str(v)
+            if hasattr(v, "isoformat"):
+                return v.isoformat()
+            return v
+
+        payload = {k: conv(v) for k, v in data.model_dump().items()}
         resp = await ac.post("/vectors/index", json=payload, params={"user_id": str(user_id)})
         assert resp.status_code == 200
         emb_id = resp.json()["embedding_id"]


### PR DESCRIPTION
## Summary
- expand user style analysis with sentiment and emotion statistics
- provide deterministic fallback in EmbeddingService when no model is available
- adjust vector API mock test to handle datetimes
- verify new fields in style analyzer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a03c3c94832cb7aaaa0e3e5607e4