### PR TITLE
Add feedback history endpoint

### DIFF
--- a/backend/app/digital_twin/api/digital_twin.py
+++ b/backend/app/digital_twin/api/digital_twin.py
@@ -31,3 +31,11 @@ async def feedback(twin_id: UUID, message: str, rating: int) -> dict:
         raise HTTPException(status_code=404, detail="twin not found")
     success = await service.feedback.record_feedback(twin_id, message, rating)
     return {"success": success}
+
+
+@router.get("/{twin_id}/feedback")
+async def feedback_history(twin_id: UUID) -> dict:
+    if twin_id not in service.twins:
+        raise HTTPException(status_code=404, detail="twin not found")
+    history = service.feedback.get_feedback_history(twin_id)
+    return {"feedback": history}

--- a/backend/app/digital_twin/services/feedback_handler.py
+++ b/backend/app/digital_twin/services/feedback_handler.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 from uuid import UUID
+from typing import Dict, List, Tuple
 
 
 class FeedbackHandler:
-    """Placeholder for continual learning feedback."""
+    """In-memory feedback storage for Digital Twins."""
+
+    def __init__(self) -> None:
+        self._store: Dict[UUID, List[Tuple[str, int]]] = {}
 
     async def record_feedback(self, twin_id: UUID, message: str, rating: int) -> bool:
-        # In a real system this would update training data
+        """Record feedback for a digital twin."""
+        self._store.setdefault(twin_id, []).append((message, rating))
         return True
+
+    def get_feedback_history(self, twin_id: UUID) -> List[Tuple[str, int]]:
+        """Retrieve feedback history for a digital twin."""
+        return list(self._store.get(twin_id, []))

--- a/backend/tests/test_digital_twin.py
+++ b/backend/tests/test_digital_twin.py
@@ -21,6 +21,10 @@ async def test_create_and_generate():
     response = await service.generate_response(twin.id, "Hello")
     assert "Tester" in response
 
+    await service.feedback.record_feedback(twin.id, "msg", 5)
+    history = service.feedback.get_feedback_history(twin.id)
+    assert ("msg", 5) in history
+
 
 @pytest.mark.asyncio
 async def test_api_endpoints():
@@ -47,3 +51,10 @@ async def test_api_endpoints():
         resp = await ac.post(f"/digital-twin/{twin_id}/generate", params={"query": "hi"})
         assert resp.status_code == 200
         assert "Tester" in resp.json()["response"]
+
+        resp = await ac.post(f"/digital-twin/{twin_id}/feedback", params={"message": "ok", "rating": 1})
+        assert resp.status_code == 200
+
+        resp = await ac.get(f"/digital-twin/{twin_id}/feedback")
+        assert resp.status_code == 200
+        assert ["ok", 1] == resp.json()["feedback"][0]


### PR DESCRIPTION
## Summary
- implement in-memory feedback store
- add endpoint to get feedback history
- test feedback handling via service and API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887497925b8832ca799df5b766f04a5