### PR TITLE
Restrict deploy job to main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
         run: pytest -q
 
   deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'msingatullin/ai-orchestrator'
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- narrow `deploy` job conditions in CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688773043674832cad0f9c82be89da70