### PR TITLE
Fix README missing in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock* /app/
+# Copy project metadata including README before installing
+COPY pyproject.toml poetry.lock* README.md /app/
 # Install the project itself so that the `backend` package is available
 RUN pip install --no-cache-dir poetry && poetry install
 


### PR DESCRIPTION
## Summary
- ensure README.md is included when building the Docker image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688799349e20832c8befe70b5c40694c