### PR TITLE
Fix Docker build path issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 # Copy project metadata including README before installing
 COPY pyproject.toml poetry.lock* README.md /app/
+# Copy backend source early so Poetry can install the package
+COPY backend /app/backend
 # Install the project itself so that the `backend` package is available
 RUN pip install --no-cache-dir poetry && poetry install
 


### PR DESCRIPTION
## Summary
- copy backend source before running `poetry install`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887dda0eea4832cb2760f015ce36f8c