### PR TITLE
Fix Alembic url config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 # Copy project metadata including README before installing
 COPY pyproject.toml poetry.lock* README.md /app/
+# Copy backend source early so Poetry can install the package
+COPY backend /app/backend
 # Install the project itself so that the `backend` package is available
 RUN pip install --no-cache-dir poetry && poetry install
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -5,10 +5,14 @@ from sqlalchemy import pool
 
 from alembic import context
 from backend.app.models import Base
+import os
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./backend:/app/backend
-      - ./alembic:/app/alembic
+      - ./backend/migrations:/app/alembic
       - ./alembic.ini:/app/alembic.ini
       - ./entrypoint.sh:/app/entrypoint.sh
 

--- a/setup_orchestrator.sh
+++ b/setup_orchestrator.sh
@@ -23,7 +23,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./backend:/app/backend
-      - ./alembic:/app/alembic
+      - ./backend/migrations:/app/alembic
       - ./alembic.ini:/app/alembic.ini
       - ./entrypoint.sh:/app/entrypoint.sh
 


### PR DESCRIPTION
## Summary
- inject `DATABASE_URL` into Alembic config so migrations run in Docker

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887dda0eea4832cb2760f015ce36f8c